### PR TITLE
Bug fixes and tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,14 @@ Once the process finishes a new AMI will be ready for use in the selected region
 
 The AMI created by this template supports setting the concourse basic-auth username and password via [user-data](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html) when the instance is boooted. 
 
-This is done by providing a simple YAML document that contains `username` and `password` keys as the instance's user-data:
+This is done by providing a simple YAML document that contains `username` and `password` keys as the instance's user-data. The `hostname` key is optional, but if set will be passed as `external-url` to concourse.  If `hostname` is not provided, then the `public-hostname` from the metadata service will be used
 
 ```
 # This is a sample YAML file that will configure the concourse username and password
 
 username: admin
 password: swordfish
+hostname: ci.example.com
 ```
 
 #### Accessing Concourse

--- a/cookbooks/concourse/files/extract_yaml_key.py
+++ b/cookbooks/concourse/files/extract_yaml_key.py
@@ -10,6 +10,9 @@ class TestStringMethods(unittest.TestCase):
   TEST_YAML_GOOD = """
   foo: bar
   baz: bork
+  pipeline:
+    this: is a
+    nested: structure
   """
 
   TEST_YAML_BLANK = ''
@@ -26,6 +29,11 @@ class TestStringMethods(unittest.TestCase):
     """A value can be extracted from valid yaml"""
     assert extract_key(self.TEST_YAML_GOOD, 'foo') == 'bar'
 
+  def test_nested(self):
+    """nested values are returned as a full yaml document"""
+    y = yaml.load(self.TEST_YAML_GOOD)
+    assert extract_key(self.TEST_YAML_GOOD, 'pipeline') == yaml.dump(y.get('pipeline'))
+
   def test_extract_missing(self):
     """A default is returned if the key is not found in valid yaml"""
     assert extract_key(self.TEST_YAML_GOOD, 'bar', 'hello') == 'hello'
@@ -35,7 +43,7 @@ class TestStringMethods(unittest.TestCase):
     assert extract_key(self.TEST_YAML_BLANK, 'bar', 'hello') == 'hello'
 
   def test_extract_bad(self):
-    """A default is returned if blank is provided"""
+    """A default is returned if invalid yaml is provided"""
     assert extract_key(self.TEST_NOT_YAML, 'bar', 'hello') == 'hello'
   
 
@@ -54,7 +62,12 @@ def extract_key(content, kk, default=None):
 
   try:
     y = yaml.load(content)
-    return y.get(kk, default)
+    value = y.get(kk, default)
+
+    if type(value) is dict:
+      return yaml.dump(value)
+    else:
+      return value
   except:
     return default
 

--- a/cookbooks/concourse/recipes/default.rb
+++ b/cookbooks/concourse/recipes/default.rb
@@ -1,7 +1,7 @@
 package 'linux-generic-lts-vivid'
 package 'postgresql'
 
-db_password = shell_out("openssl rand -base64 32").stdout.strip
+db_password = shell_out("tr -cd '[:alnum:]' < /dev/urandom | fold -w30 | head -n1").stdout.strip
 
 concourse_binary_release = shell_out("curl https://api.github.com/repos/concourse/concourse/releases | grep browser_download_url | grep 'linux_amd64' | head -n 1 | cut -d'\"' -f4").stdout.strip
 

--- a/cookbooks/concourse/templates/certgen.erb
+++ b/cookbooks/concourse/templates/certgen.erb
@@ -1,0 +1,24 @@
+set -e
+
+BASE_DIR="/opt/concourse"
+
+# get our hostname from the userdata / metadata service
+. $BASE_DIR/bin/_userdata.sh
+
+TMPDIR=$(mktemp -d)
+
+openssl req \
+  -days 1 \
+  -newkey rsa:2048 \
+  -nodes \
+  -new \
+  -x509 \
+  -subj "/CN=$HOSTNAME" \
+  -keyout $TMPDIR/server.key \
+  -out $TMPDIR/server.crt
+
+cat $TMPDIR/server.* > /etc/ssl/self_signed.pem
+
+rm $TMPDIR/server.* && rmdir $TMPDIR
+
+ENABLED=1

--- a/cookbooks/concourse/templates/fly-bootstrap.erb
+++ b/cookbooks/concourse/templates/fly-bootstrap.erb
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+BASE_DIR="/opt/concourse"
+
+USERNAME=$(curl http://169.254.169.254/latest/user-data | $BASE_DIR/bin/extract_yaml_key username <%= @ci_default_username %>)
+PASSWORD=$(curl http://169.254.169.254/latest/user-data | $BASE_DIR/bin/extract_yaml_key password <%= @ci_default_password %>)
+PIPELINE=$(curl http://169.254.169.254/latest/user-data | $BASE_DIR/bin/extract_yaml_key pipeline)
+
+if [ -z "$PIPELINE" ]; then
+	echo "No pipeline supplied in user-data. Exiting."
+	exit 0;
+fi
+
+PIPELINE_FILE=$(mktemp)
+
+echo -e "$PIPELINE" > $PIPELINE_FILE
+
+# wait for server to be up, upstart shouldn't start us until ready, but concourse still has startup time
+echo "Waiting for concourse to start..."
+until nc -z localhost 8080; do sleep 1; done
+
+# login
+NAME="local"
+
+$BASE_DIR/bin/fly login -t $NAME -c http://localhost:8080 -u $USERNAME -p $PASSWORD
+
+# wait for concourse to be ready (i.e. have workers)
+echo "Waiting for worker to be ready..."
+until $BASE_DIR/bin/fly -t $NAME workers 2>&1| grep linux; do sleep 1; done
+
+# install pipeline
+$BASE_DIR/bin/fly -t $NAME sp -p bootstrap -c $PIPELINE_FILE  -n
+
+# start it
+$BASE_DIR/bin/fly -t $NAME up -p bootstrap

--- a/cookbooks/concourse/templates/fly-bootstrap.erb
+++ b/cookbooks/concourse/templates/fly-bootstrap.erb
@@ -2,9 +2,7 @@
 
 BASE_DIR="/opt/concourse"
 
-USERNAME=$(curl http://169.254.169.254/latest/user-data | $BASE_DIR/bin/extract_yaml_key username <%= @ci_default_username %>)
-PASSWORD=$(curl http://169.254.169.254/latest/user-data | $BASE_DIR/bin/extract_yaml_key password <%= @ci_default_password %>)
-PIPELINE=$(curl http://169.254.169.254/latest/user-data | $BASE_DIR/bin/extract_yaml_key pipeline)
+source $BASE_DIR/bin/_userdata.sh
 
 if [ -z "$PIPELINE" ]; then
 	echo "No pipeline supplied in user-data. Exiting."

--- a/cookbooks/concourse/templates/fly-init.erb
+++ b/cookbooks/concourse/templates/fly-init.erb
@@ -1,0 +1,3 @@
+start on (started concourse-web and started concourse-worker)
+
+exec /opt/concourse/bin/fly-bootstrap

--- a/cookbooks/concourse/templates/haproxy.erb
+++ b/cookbooks/concourse/templates/haproxy.erb
@@ -1,0 +1,34 @@
+global
+	log /dev/log	local0
+	log /dev/log	local1 notice
+	chroot /var/lib/haproxy
+	user haproxy
+	group haproxy
+	daemon
+	tune.ssl.default-dh-param 2048
+
+defaults
+	log	global
+	mode	tcp
+	option	tcplog
+	option	dontlognull
+	timeout connect  5000
+	timeout client  10000
+	timeout server  10000
+	errorfile 400 /etc/haproxy/errors/400.http
+	errorfile 403 /etc/haproxy/errors/403.http
+	errorfile 408 /etc/haproxy/errors/408.http
+	errorfile 500 /etc/haproxy/errors/500.http
+	errorfile 502 /etc/haproxy/errors/502.http
+	errorfile 503 /etc/haproxy/errors/503.http
+	errorfile 504 /etc/haproxy/errors/504.http
+
+frontend term
+	bind :443 ssl crt /etc/ssl/self_signed.pem
+
+	redirect scheme https code 301 if !{ ssl_fc }
+
+	default_backend concourse
+
+backend concourse
+	server local 127.0.0.1:8080

--- a/cookbooks/concourse/templates/userdata.erb
+++ b/cookbooks/concourse/templates/userdata.erb
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+BASE_DIR="/opt/concourse"
+
+export USERNAME="$(curl http://169.254.169.254/latest/user-data | $BASE_DIR/bin/extract_yaml_key username <%= @ci_default_username %>)"
+export PASSWORD="$(curl http://169.254.169.254/latest/user-data | $BASE_DIR/bin/extract_yaml_key password <%= @ci_default_password %>)"
+export PIPELINE="$(curl http://169.254.169.254/latest/user-data | $BASE_DIR/bin/extract_yaml_key pipeline)"
+
+export AWS_HOSTNAME="$(curl http://169.254.169.254/latest/meta-data/public-hostname)"
+
+export HOSTNAME="$(curl http://169.254.169.254/latest/user-data | $BASE_DIR/bin/extract_yaml_key hostname $AWS_HOSTNAME)"

--- a/cookbooks/concourse/templates/web.erb
+++ b/cookbooks/concourse/templates/web.erb
@@ -2,16 +2,23 @@
 
 BASE_DIR="/opt/concourse"
 
+export AWS_HOSTNAME=$(curl http://169.254.169.254/latest/meta-data/public-hostname)
+
 USERNAME=$(curl http://169.254.169.254/latest/user-data | $BASE_DIR/bin/extract_yaml_key username ci)
 PASSWORD=$(curl http://169.254.169.254/latest/user-data | $BASE_DIR/bin/extract_yaml_key password walt)
+HOSTNAME=$(curl http://169.254.169.254/latest/user-data | $BASE_DIR/bin/extract_yaml_key hostname $AWS_HOSTNAME)
+
+# setup port 80 forwarding
+export RULE="PREROUTING -i eth0 -p tcp --dport 80 -j REDIRECT --to-port 8080"
+iptables -t nat -C $RULE || iptables -t nat -A $RULE
 
 $BASE_DIR/bin/concourse web \
-    --bind-port 80 \
+    --bind-port 8080 \
     --basic-auth-username $USERNAME \
     --basic-auth-password $PASSWORD \
     --session-signing-key $BASE_DIR/etc/session_signing_key \
     --tsa-host-key $BASE_DIR/etc/host_key \
     --tsa-authorized-keys $BASE_DIR/etc/worker_key.pub \
     --postgres-data-source='postgres://atc:<%= @db_password %>@127.0.0.1:5432/atc?sslmode=disable' \
-    --external-url http://`curl http://169.254.169.254/latest/meta-data/public-hostname` \
+    --external-url http://$HOSTNAME \
 | tee /var/log/concourse-web.log

--- a/cookbooks/concourse/templates/web.erb
+++ b/cookbooks/concourse/templates/web.erb
@@ -4,8 +4,8 @@ BASE_DIR="/opt/concourse"
 
 export AWS_HOSTNAME=$(curl http://169.254.169.254/latest/meta-data/public-hostname)
 
-USERNAME=$(curl http://169.254.169.254/latest/user-data | $BASE_DIR/bin/extract_yaml_key username ci)
-PASSWORD=$(curl http://169.254.169.254/latest/user-data | $BASE_DIR/bin/extract_yaml_key password walt)
+USERNAME=$(curl http://169.254.169.254/latest/user-data | $BASE_DIR/bin/extract_yaml_key username <%= @ci_default_username %>)
+PASSWORD=$(curl http://169.254.169.254/latest/user-data | $BASE_DIR/bin/extract_yaml_key password <%= @ci_default_password %>)
 HOSTNAME=$(curl http://169.254.169.254/latest/user-data | $BASE_DIR/bin/extract_yaml_key hostname $AWS_HOSTNAME)
 
 # setup port 80 forwarding

--- a/cookbooks/concourse/templates/web.erb
+++ b/cookbooks/concourse/templates/web.erb
@@ -2,15 +2,7 @@
 
 BASE_DIR="/opt/concourse"
 
-export AWS_HOSTNAME=$(curl http://169.254.169.254/latest/meta-data/public-hostname)
-
-USERNAME=$(curl http://169.254.169.254/latest/user-data | $BASE_DIR/bin/extract_yaml_key username <%= @ci_default_username %>)
-PASSWORD=$(curl http://169.254.169.254/latest/user-data | $BASE_DIR/bin/extract_yaml_key password <%= @ci_default_password %>)
-HOSTNAME=$(curl http://169.254.169.254/latest/user-data | $BASE_DIR/bin/extract_yaml_key hostname $AWS_HOSTNAME)
-
-# setup port 80 forwarding
-export RULE="PREROUTING -i eth0 -p tcp --dport 80 -j REDIRECT --to-port 8080"
-iptables -t nat -C $RULE || iptables -t nat -A $RULE
+source $BASE_DIR/bin/_userdata.sh
 
 $BASE_DIR/bin/concourse web \
     --bind-port 8080 \
@@ -20,5 +12,5 @@ $BASE_DIR/bin/concourse web \
     --tsa-host-key $BASE_DIR/etc/host_key \
     --tsa-authorized-keys $BASE_DIR/etc/worker_key.pub \
     --postgres-data-source='postgres://atc:<%= @db_password %>@127.0.0.1:5432/atc?sslmode=disable' \
-    --external-url http://$HOSTNAME \
+    --external-url https://$HOSTNAME \
 | tee /var/log/concourse-web.log


### PR DESCRIPTION
- Switch to a different method for generating password
  
  The old version was not alphanum and could generate characters like @ or / that break postgres connection string
- Allow specifying`hostname` in user-data
  
  This is passed to concourse's `--external-url`, if not provided, the `public-hostname` from ec2 metadata is used
- Allow specifying `pipeline` in user-data 

The VM will fly (and unpause) this pipeline to itself, at boot time.
- Protect concourse with TLS (terminated by HAProxy)
